### PR TITLE
Feature/applescript eol error

### DIFF
--- a/get-current-url.applescript
+++ b/get-current-url.applescript
@@ -1,81 +1,81 @@
 on appIsRunning(appName)
-	tell application "System Events" to (name of processes) contains appName
+  tell application "System Events" to (name of processes) contains appName
 end appIsRunning
 
 
 on run
-	set theApplication to (name of (info for (path to frontmost application)))
-	set theText to ""
-	set theURL to ""
-
-	if theApplication is "Google Chrome.app" and appIsRunning("Google Chrome") then
-		set theResult to run script "tell application id \"com.google.chrome\"
-			using terms from application \"Google Chrome\"
-				set theText to title of active tab of first window
-				set theURL to get URL of active tab of first window
-				return {theURL, theText}
-			end using terms from
-		end tell"
-		set theURL to item 1 of theResult
-		set theText to item 2 of theResult
-
-    else if theApplication is "Vivaldi.app" and appIsRunning("Vivaldi") then
-        set theResult to run script "tell application id \"com.vivaldi.Vivaldi\"
-            using terms from application \"Vivaldi\"
-                set theText to title of active tab of first window
-                set theURL to get URL of active tab of first window
-                return {theURL, theText}
-            end using terms from
-        end tell"
-        set theURL to item 1 of theResult
-        set theText to item 2 of theResult
-
-	else if theApplication is "Safari.app" and appIsRunning("Safari") then
-		set theResult to run script "tell application id \"com.apple.safari\"
-			using terms from application \"Safari\"
-				set theTab to front document
-				set theText to name of theTab
-				set theURL to URL of theTab
-				return {theURL, theText}
-			end using terms from
-		end tell"
-		set theURL to item 1 of theResult
-		set theText to item 2 of theResult
-
-	else if theApplication is "Chromium.app" and appIsRunning("Chromium") then
-		set theResult to run script "tell application \"Chromium\"
-			set theURL to URL of active tab of first window
-			set theText to title of active tab of first window
-			return {theURL, theText}
-		end tell"
-		set theURL to item 1 of theResult
-		set theText to item 2 of theResult
-
-	else if theApplication is "Firefox.app" and appIsRunning("Firefox") then
-		set theResult to run script "tell application id \"org.mozilla.firefox\"
-			activate
-			set w to item 1 of window 1
-			set theText to name of w
-		end tell
-		tell application \"System Events\"
-			set myApp to name of first application process whose frontmost is true
-			if myApp is \"Firefox\" then
-				tell application \"System Events\"
-					keystroke \"l\" using command down
-					delay 0.5
-					keystroke \"c\" using command down
-				end tell
-				delay 0.5
-			end if
-			delay 0.5
-		end tell
-		set theURL to get the clipboard
-		return {theURL, theText}"
-		set theURL to item 1 of theResult
-		set theText to item 2 of theResult
-
-	end if
-
-	return {theURL & " @@@@@ " & theText}
-
+  set theApplication to (name of (info for (path to frontmost application)))
+  set theText to ""
+  set theURL to ""
+  
+  if theApplication is "Google Chrome.app" and appIsRunning("Google Chrome") then
+    set theResult to run script "tell application id \"com.google.chrome\"
+      using terms from application \"Google Chrome\"
+        set theText to title of active tab of first window
+        set theURL to get URL of active tab of first window
+        return {theURL, theText}
+      end using terms from
+    end tell"
+    set theURL to item 1 of theResult
+    set theText to item 2 of theResult
+    
+  else if theApplication is "Vivaldi.app" and appIsRunning("Vivaldi") then
+    set theResult to run script "tell application id \"com.vivaldi.Vivaldi\"
+      using terms from application \"Vivaldi\"
+        set theText to title of active tab of first window
+        set theURL to get URL of active tab of first window
+        return {theURL, theText}
+      end using terms from
+    end tell"
+    set theURL to item 1 of theResult
+    set theText to item 2 of theResult
+    
+  else if theApplication is "Safari.app" and appIsRunning("Safari") then
+    set theResult to run script "tell application id \"com.apple.safari\"
+      using terms from application \"Safari\"
+        set theTab to front document
+        set theText to name of theTab
+        set theURL to URL of theTab
+        return {theURL, theText}
+      end using terms from
+    end tell"
+    set theURL to item 1 of theResult
+    set theText to item 2 of theResult
+    
+  else if theApplication is "Chromium.app" and appIsRunning("Chromium") then
+    set theResult to run script "tell application \"Chromium\"
+      set theURL to URL of active tab of first window
+      set theText to title of active tab of first window
+      return {theURL, theText}
+    end tell"
+    set theURL to item 1 of theResult
+    set theText to item 2 of theResult
+    
+  else if theApplication is "Firefox.app" and appIsRunning("Firefox") then
+    set theResult to run script "tell application id \"org.mozilla.firefox\"
+      activate
+      set w to item 1 of window 1
+      set theText to name of w
+    end tell
+    tell application \"System Events\"
+      set myApp to name of first application process whose frontmost is true
+      if myApp is \"Firefox\" then
+        tell application \"System Events\"
+          keystroke \"l\" using command down
+          delay 0.5
+          keystroke \"c\" using command down
+        end tell
+        delay 0.5
+      end if
+      delay 0.5
+    end tell
+    set theURL to get the clipboard
+    return {theURL, theText}"
+    set theURL to item 1 of theResult
+    set theText to item 2 of theResult
+    
+  end if
+  
+  return {theURL & " @@@@@ " & theText}
+  
 end run

--- a/get-current-url.applescript
+++ b/get-current-url.applescript
@@ -10,34 +10,28 @@ on run
   
   if theApplication is "Google Chrome.app" and appIsRunning("Google Chrome") then
     set theResult to run script "tell application id \"com.google.chrome\"
-      using terms from application \"Google Chrome\"
-        set theText to title of active tab of first window
-        set theURL to get URL of active tab of first window
-        return {theURL, theText}
-      end using terms from
+      set theText to title of active tab of first window
+      set theURL to get URL of active tab of first window
+      return {theURL, theText}
     end tell"
     set theURL to item 1 of theResult
     set theText to item 2 of theResult
     
   else if theApplication is "Vivaldi.app" and appIsRunning("Vivaldi") then
     set theResult to run script "tell application id \"com.vivaldi.Vivaldi\"
-      using terms from application \"Vivaldi\"
-        set theText to title of active tab of first window
-        set theURL to get URL of active tab of first window
-        return {theURL, theText}
-      end using terms from
+      set theText to title of active tab of first window
+      set theURL to get URL of active tab of first window
+      return {theURL, theText}
     end tell"
     set theURL to item 1 of theResult
     set theText to item 2 of theResult
     
   else if theApplication is "Safari.app" and appIsRunning("Safari") then
     set theResult to run script "tell application id \"com.apple.safari\"
-      using terms from application \"Safari\"
-        set theTab to front document
-        set theText to name of theTab
-        set theURL to URL of theTab
-        return {theURL, theText}
-      end using terms from
+      set theTab to front document
+      set theText to name of theTab
+      set theURL to URL of theTab
+      return {theURL, theText}
     end tell"
     set theURL to item 1 of theResult
     set theText to item 2 of theResult


### PR DESCRIPTION
Fixes `Expected end of line but found property` error coming from `get-current-url.applescript` while pinning a url using Google Chrome.
- OSX 10.11.5
- Google Chrome 50.0.2661.102

Removing the `using terms from application` fixes the error. The pull request will remove the part mentioned for
- Google Chrome
- Vivaldi
- Safari

PR changes were tested against
- Google Chrome 50.0.2661.102
- Vivaldi 1.2.490.39
- Safari 9.1.1

See also: http://leancrew.com/all-this/2011/09/applescript-browser-tab-weirdness/
